### PR TITLE
Requiring helm-files.

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -37,6 +37,7 @@
 (eval-when-compile (require 'cl))
 (require 'vc-git)
 (require 'helm)
+(require 'helm-files)
 (require 'helm-fix-multiline-process)
 
 (defun helm-git-grep-find-git-root ()


### PR DESCRIPTION
Hello!

Thanks for the such a useful mode. :) It helps me a lot on my job. But I found some sort of a bug which irritates me.

When you call helm-git-grep right after the start of Emacs all search results look plain and unactive. They are really unactive. Pressing Enter doesn't work.

![unactive](http://i.imgur.com/1wH9aWU.png)

After calling some other helm functions (for example helm-find-files) helm-git-grep starts working correctly.

![active](http://i.imgur.com/DR9oeI1.png)

Looks like something doesn't load properly. This is probably a helm's bug, I don't know, further investigation is needed. But it can be fixed just by requiring helm-files.

If you don't mind, please merge this pull request.

Thanks.
