### PR TITLE
modernize source declaration to support latest helm

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -501,30 +501,37 @@ You can save your results in a helm-git-grep-mode buffer, see below.
     (delq nil map))
   "Keymap used in Git Grep sources.")
 
-(define-helm-type-attribute 'git-grep
-  `((default-directory . nil)
-    (requires-pattern . 3)
-    (volatile)
-    (delayed)
-    (filtered-candidate-transformer
-     helm-git-grep-filtered-candidate-transformer-file-line)
-    (action . ,helm-git-grep-actions)
-    (history . ,'helm-git-grep-history)
-    (persistent-action . helm-git-grep-persistent-action)
-    (persistent-help . "Jump to line (`C-u' Record in mark ring)")
-    (keymap . ,helm-git-grep-map)
-    (mode-line . helm-git-grep-mode-line-string)
-    (init . helm-git-grep-init)))
+(eval `(defclass helm-git-grep-source (helm-source-async)
+         ((default-directory
+            :initform nil)
+          (requires-pattern
+           :initform 3)
+          (volatile
+           :initform t)
+          (filtered-candidate-transformer
+           :initform helm-git-grep-filtered-candidate-transformer-file-line)
+          (action
+           :initform ,helm-git-grep-actions)
+          (history
+           :initform ,'helm-git-grep-history)
+          (persistent-action
+           :initform helm-git-grep-persistent-action)
+          (persistent-help
+           :initform "Jump to line (`C-u' Record in mark ring)")
+          (keymap
+           :initform ,helm-git-grep-map)
+          (mode-line
+           :initform helm-git-grep-mode-line-string)
+          (init
+           :initform helm-git-grep-init))))
 
 (defvar helm-source-git-grep
-  '((name . "Git Grep")
-    (candidates-process . helm-git-grep-process)
-    (type . git-grep)))
+  (helm-make-source "Git Grep" 'helm-git-grep-source
+    :candidates-process 'helm-git-grep-process))
 
 (defvar helm-source-git-submodule-grep
-  '((name . "Git Submodule Grep")
-    (candidates-process . helm-git-submodule-grep-process)
-    (type . git-grep)))
+  (helm-make-source "Git Submodule Grep" 'helm-git-grep-source
+    :candidates-process 'helm-git-submodule-grep-process))
 
 (defun helm-git-grep-1 (&optional input)
   "Execute helm git grep.


### PR DESCRIPTION
https://github.com/emacs-helm/helm/commit/8517c86be8f001f4f85f1ade337e26666a784f52 removed the helm-git-grep way to declare sources, this commit uses the new class system.