### PR TITLE
Add regexp-quote to grep-at-point.

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -565,7 +565,7 @@ if submodules exists, grep submodules too."
          (input (if symbol (concat symbol " ") nil)))
     (when (and helm-git-grep-at-point-deactivate-mark mark-active)
       (deactivate-mark)) ;; remove any active regions
-    (helm-git-grep-1 input)))
+    (helm-git-grep-1 (regexp-quote input))))
 
 ;;;###autoload
 (defun helm-git-grep-with-exclude-file-pattern ()


### PR DESCRIPTION
Fixes this issue: https://github.com/yasuyk/helm-git-grep/issues/18

Alternatively, we could introduce a variable to optionally apply regexp-quote if the user doesn't want to escape special characters: []* etc.