### PR TITLE
Fixed: when cursor on empty line result in `nil' error.

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -562,7 +562,7 @@ if submodules exists, grep submodules too."
   (interactive)
   (let* ((symbol (if (not mark-active) (thing-at-point 'symbol)
                    (when (use-region-p) (buffer-substring (region-beginning) (region-end)))))
-         (input (if symbol (concat symbol " ") nil)))
+         (input (if symbol (concat symbol " ") "")))
     (when (and helm-git-grep-at-point-deactivate-mark mark-active)
       (deactivate-mark)) ;; remove any active regions
     (helm-git-grep-1 input)))


### PR DESCRIPTION
When we use `helm-git-grep-at-point`, I think when cursor on a empty line,
should popup a helm-git-grep session which no any keyword exist.

Not a error message which told me:  ```helm-git-grep-1: Wrong type argument: stringp, nil```