### PR TITLE
 Use --null to disambiguate numeric filenames 

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -66,7 +66,7 @@ If you don't want to search in submodules, \
 Set only `helm-git-grep-source' like this:
 
     (setq helm-git-grep-sources '(helm-git-grep-source))"
-  :group 'helm-gi-grep
+  :group 'helm-git-grep
   :type '(repeat (choice symbol)))
 
 (defcustom helm-git-grep-candidate-number-limit 300

--- a/test/helm-git-grep-test.el
+++ b/test/helm-git-grep-test.el
@@ -79,25 +79,25 @@
         (helm-pattern "defun helm git")
         (helm-git-grep-pathspecs nil))
     (should-equal? (helm-git-grep-args)
-                   '("--no-pager" "grep" "-n" "--no-color" "-i"
+                   '("--no-pager" "grep" "--null" "-n" "--no-color" "-i"
                      "-e" "defun" "--and" "-e" "helm" "--and" "-e" "git")))
   (let ((helm-git-grep-ignore-case nil)
         (helm-pattern "helm")
         (helm-git-grep-pathspecs nil))
     (should-equal? (helm-git-grep-args)
-                   '("--no-pager" "grep" "-n" "--no-color" "-e" "helm")))
+                   '("--no-pager" "grep" "--null" "-n" "--no-color" "-e" "helm")))
   (let ((helm-git-grep-ignore-case nil)
         (helm-pattern "helm")
         (helm-git-grep-pathspecs '("./*" ":!test/**")))
     (should-equal? (helm-git-grep-args)
-                   '("--no-pager" "grep" "-n" "--no-color" "-e" "helm"
+                   '("--no-pager" "grep" "--null" "-n" "--no-color" "-e" "helm"
                      "--" "./*" ":!test/**")))
   (let ((helm-git-grep-ignore-case nil)
         (helm-pattern "helm")
         (helm-git-grep-pathspecs '("./*" ":!test/**"))
         (helm-git-grep-pathspec-available nil))
     (should-equal? (helm-git-grep-args)
-                   '("--no-pager" "grep" "-n" "--no-color" "-e" "helm"))))
+                   '("--no-pager" "grep" "--null" "-n" "--no-color" "-e" "helm"))))
 
 (ert-deftest test/helm-git-grep-highlight-match ()
   (let* ((helm-input "defun")


### PR DESCRIPTION
Fixes opening files from results with filenames such as "1-2-3".

Unfortunately the output of `git grep --null` doesn't distinguish between matching and context lines, so that information is lost.

An alternative would be to use `--color` and specify ` color.grep.*` explicitly on the command-line, though that is potentially more fragile and doesn't provide perfect escaping (a file name *may* contain an ANSI color sequence on POSIX).

I would like to add a test for this, however there doesn't appear to be any tests which actually invoke `git grep`, so the only option would be to test parsing of simulated `git` output.