### PR TITLE
Specify default value for helm-git-grep's helm invocation

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -664,6 +664,7 @@ Optional argument INPUT is initial input."
         :buffer "*helm git grep*"
         :input input
         :keymap helm-git-grep-map
+        :default (helm-git-grep-get-input-symbol)
         :candidate-number-limit helm-git-grep-candidate-number-limit))
 
 ;;;###autoload


### PR DESCRIPTION
This allows pasting the symbol under point just by pressing `M-n` in `helm`, without needing to invoke `helm-git-grep-at-point` specifically.

Inspired by https://github.com/yasuyk/helm-git-grep/issues/7.