### PR TITLE
Add wordgrep toggle option

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -91,6 +91,11 @@ Set it to nil if you don't want this limit."
   :group 'helm-git-grep
   :type  'boolean)
 
+(defcustom helm-git-grep-wordgrep t
+  "Wordgrep when matching."
+  :group 'helm-git-grep
+  :type  'boolean)
+
 (defcustom helm-git-grep-showing-leading-and-trailing-lines nil
   "Show leading and trailing lines."
   :group 'helm-git-grep
@@ -134,18 +139,21 @@ you can check limit paths by pathspec using
   :type '(repeat string  :tag "Pathspec"))
 
 (defcustom helm-git-grep-doc-order-in-name-header
-  '(pathspec basedir ignorecase)
+  '(pathspec basedir wordgrep ignorecase)
   "List of doc in name header for git-grep(1).
 list of following possible values:
     pathspec: if `helm-git-grep-pathspecs' is not nil, \
 availability of `helm-git-grep-pathspecs' and key of toggle command.
     basedir: value of `helm-git-grep-base-directory' \
 and key of toggle command.
+    wordgrep: if `helm-git-grep-wordgrep' is t, show [w] \
+and key of toggle command.
     ignorecase: if `helm-git-grep-ignore-case' is t, show [i] \
 and key of toggle command."
   :group 'helm-git-grep
   :type '(repeat (choice (const :tag "PathSpecs" pathspec)
                          (const :tag "BaseDirectory" basedir)
+                         (const :tag "WordGrep" wordgrep)
                          (const :tag "IgnoreCase" ignorecase))))
 
 
@@ -195,6 +203,11 @@ and key of toggle command."
      :function
      (lambda (doc)
        (format doc (symbol-name helm-git-grep-base-directory))))
+    wordgrep
+    (:doc
+     "[helm-git-grep-toggle-wordgrep]:Tog.wordgrep%s"
+     :function
+     (lambda (doc) (format doc (if helm-git-grep-wordgrep "[w]" ""))))
     ignorecase
     (:doc
      "[helm-git-grep-toggle-ignore-case]:Tog.ignorecase%s"
@@ -252,6 +265,7 @@ newline return an empty string."
         (append
          (list "--no-pager" "grep" "--null" "-n" "--no-color"
                (if helm-git-grep-ignore-case "-i" nil)
+               (if helm-git-grep-wordgrep "-w" nil)
                (helm-git-grep-showing-leading-and-trailing-lines-option))
          (nbutlast
           (apply 'append
@@ -263,8 +277,9 @@ newline return an empty string."
 (defun helm-git-grep-submodule-grep-command ()
   "Create command of `helm-git-submodule-grep-process' in `helm-git-grep'."
   (list "git" "--no-pager" "submodule" "--quiet" "foreach"
-       (format "git grep -n --no-color %s %s %s | sed s!^!$path/!"
+       (format "git grep -n --no-color %s %s %s %s | sed s!^!$path/!"
                (if helm-git-grep-ignore-case "-i" "")
+               (if helm-git-grep-wordgrep "-w" "")
                (helm-git-grep-showing-leading-and-trailing-lines-option t)
                 (mapconcat (lambda (x)
                              (format "-e %s " (shell-quote-argument x)))
@@ -530,6 +545,13 @@ With a prefix arg record CANDIDATE in `mark-ring'."
   (helm-git-grep-rerun-with-input))
 (put 'helm-git-grep-toggle-ignore-case 'helm-only t)
 
+(defun helm-git-grep-toggle-wordgrep ()
+  "Toggle wordgrep option for git grep command from `helm-git-grep'."
+  (interactive)
+  (setq helm-git-grep-wordgrep (not helm-git-grep-wordgrep))
+  (helm-git-grep-rerun-with-input))
+(put 'helm-git-grep-toggle-wordgrep 'helm-only t)
+
 (defun helm-git-grep-toggle-showing-trailing-leading-line ()
   "Toggle show leading and trailing lines option for git grep."
   (interactive)
@@ -595,6 +617,7 @@ You can save your results in a helm-git-grep-mode buffer, see below.
 \\[helm-git-grep-pathspec-toggle-availability]\t\t->Toggle pathspec availability.
 \\[helm-git-grep-toggle-base-directory]\t\t->Toggle base directory for search.
 \\[helm-git-grep-toggle-ignore-case]\t\t->Toggle ignore case option.
+\\[helm-git-grep-toggle-wordgrep]\t\t->Toggle wordgrep option.
 \\[helm-git-grep-run-other-window-action]\t\t->Jump other window.
 \\[helm-git-grep-run-other-frame-action]\t\t->Jump other frame.
 \\[helm-git-grep-run-persistent-action]\t\t->Run persistent action (Same as `C-z').
@@ -620,6 +643,7 @@ You can save your results in a helm-git-grep-mode buffer, see below.
     (define-key map (kbd "C-c p")    'helm-git-grep-pathspec-toggle-availability)
     (define-key map (kbd "C-c b")    'helm-git-grep-toggle-base-directory)
     (define-key map (kbd "C-c i")    'helm-git-grep-toggle-ignore-case)
+    (define-key map (kbd "C-c w")    'helm-git-grep-toggle-wordgrep)
     (define-key map (kbd "C-c n")    'helm-git-grep-toggle-showing-trailing-leading-line)
     (define-key map (kbd "C-c e")    'helm-git-grep-run-elscreen-action)
     (define-key map (kbd "C-c o")    'helm-git-grep-run-other-window-action)


### PR DESCRIPTION
Behave similarly to ignore cases, C-w can be used to toggle
wordgrep option (-w).