### PR TITLE
Fix regexp stack overflow

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -426,6 +426,10 @@ Argument SOURCE is not used."
 
 (defun helm-git-grep-filtered-candidate-transformer-file-line-1 (candidate)
   "Transform CANDIDATE to `helm-git-grep-mode' format."
+  ; truncate any very long lines
+  (when (> (length candidate) (window-width))
+    (setq candidate (substring candidate 0 (window-width))))
+
   (when (string-match "^\\(.+\\)\x00\\([0-9]+\\)\x00\\(.*\\)$" candidate)
     (let ((filename (match-string 1 candidate))
           (lineno (match-string 2 candidate))


### PR DESCRIPTION
When I run this in some project dirs I get the following error:

  long string-length:4573
  long string-length:176
  long string-length:152007
  error in process filter: if: Stack overflow in regexp matcher
  error in process filter: Stack overflow in regexp matcher
  long string-length:117095
  error in process filter: if: Stack overflow in regexp matcher
  error in process filter: Stack overflow in regexp matcher
  long string-length:177532
  error in process filter: if: Stack overflow in regexp matcher
  error in process filter: Stack overflow in regexp matcher

This is usually because a match has hit a xml file with no newlines.
As a simple hack I truncate the string to (window-width) to avoid this
problem.