### PR TITLE
Add require for compile

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -47,6 +47,7 @@
 (eval-when-compile (require 'cl))
 (require 'helm)
 (require 'helm-files)
+(require 'compile)                      ; for define-compilation-mode
 
 (declare-function wgrep-setup-internal "ext:wgrep")
 


### PR DESCRIPTION
Otherwise, if the user hasn't already loaded compile for some reason,
an error will result.