### PR TITLE
Fix default-path for overwritten *hgrep* buffer

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -320,6 +320,7 @@ newline return an empty string."
   "Save helm git grep result in a `helm-git-grep-mode' buffer."
   (let ((prompt "GrepBufferName: ")
         (buf "*hggrep*")
+        (default-dir (helm-git-grep-base-directory))
         new-buf)
     (when (get-buffer buf)
       (setq new-buf (read-string prompt buf))
@@ -332,8 +333,7 @@ newline return an empty string."
       (setq buf new-buf))
     (with-current-buffer (get-buffer-create buf)
       (setq buffer-read-only t)
-      (let ((default-dir (helm-git-grep-base-directory))
-            (inhibit-read-only t))
+      (let ((inhibit-read-only t))
         (erase-buffer)
         (insert (format "-*- mode: grep; default-directory: \"%s\" -*-\n\n"
                         default-dir)


### PR DESCRIPTION
When overwriting an existing \*hgrep\* buffer it currently does not reset the default-path, causing it to not jump to files correctly. This is because it first navigates to the existing buffer before querying the git base path.