### PR TITLE
Support recompile (g key) to repeat the search

### DIFF
--- a/helm-git-grep.el
+++ b/helm-git-grep.el
@@ -346,6 +346,10 @@ newline return an empty string."
                     (buffer-substring (point) (point-max)))))
         (setq default-directory default-dir)
         (helm-git-grep-mode)
+        (setq-local compilation-directory default-dir)
+        (setq-local compile-command (combine-and-quote-strings
+                                     (cons "git" (remove "--null" (helm-git-grep-args)))))
+        (setq-local compilation-arguments (list compile-command 'helm-git-grep-mode))
         (pop-to-buffer buf)))
     (message "Helm Git Grep Results saved in `%s' buffer" buf)))
 


### PR DESCRIPTION
This only simulates the original way the search is done.  E.g., we can't use --null here, because the output will now be parsed by compilation-mode, not us.